### PR TITLE
Handle better /vp/ image size limit

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,8 +104,9 @@ def create_chart(in_dict: dict) -> None:
             total_img = merge_img_vertically(total_img, img_line)
         total_img = add_white_line_below(total_img)
         line += 1
-    newsize = (int(total_img.width / 4), int(total_img.height / 4))
-    total_img = total_img.resize(newsize)
+
+    if total_img.height > 5000: #/vp/ image size limit   
+        total_img = total_img.resize((int(total_img.width * 5000/total_img.height), 5000))
     total_img.save(output_filename)
 
 


### PR DESCRIPTION
Dividing the original image's dimensions by 4 is way too hacky. This solution technically isn't complete since width may exceed 5000px but even with all pairs in the same row it doesn't so it's good enough to check only height.